### PR TITLE
Fix param minute to method add_job from BlockingScheduler

### DIFF
--- a/api/report/management/commands/update_report.py
+++ b/api/report/management/commands/update_report.py
@@ -57,6 +57,6 @@ class Command(BaseCommand):
         print('Cron started! Wait the job starts!')
 
         scheduler = BlockingScheduler()
-        scheduler.add_job(cron, 'cron', minutes=20, timezone='America/Maceio')
+        scheduler.add_job(cron, 'cron', minute=20, timezone='America/Maceio')
 
         scheduler.start()


### PR DESCRIPTION
## O problema

Ao rodar o sistema é recebido um erro: 
![image](https://user-images.githubusercontent.com/1141518/77126753-f9c69a80-6a28-11ea-8d68-5279ce8e7555.png)

O problema ocorre pois o parametro  `minutes` não existe.

## Solução

Mudei para o parametro `minute` mas não tenho certeza se é a forma correta para resolver essa issue ou se é um problema de versão onde a versão usada não tem esse parametro `minutes`
